### PR TITLE
Move URLs to server.ts so we can easily see the structure at a glance

### DIFF
--- a/model/falcor.ts
+++ b/model/falcor.ts
@@ -1,3 +1,14 @@
+export interface Belief {
+  title: string;
+  content: string;
+}
+
+export interface Distinctive {
+  title: string;
+  description: string;
+  references: string;
+}
+
 export interface Event {
   coverImage: string;
   description: string;
@@ -5,6 +16,12 @@ export interface Event {
   slug: string;
   startTime: string;
   title: string;
+}
+
+export interface Ministry {
+  sermons: {
+    recent: List<Sermon>,
+  };
 }
 
 export interface Page {
@@ -18,7 +35,15 @@ export interface Person {
   slug: string;
 }
 
+export interface Series {
+  coverImage: string;
+  description: string;
+  slug: string;
+  title: string;
+}
+
 export interface Sermon {
+  content: string;
   coverImage: string;
   date: string;
   slug: string;
@@ -36,11 +61,25 @@ export interface List<T> {
  * Gives the fullest overview of what is available via the falcor API.
  */
 export interface Graph {
+  beliefs: {
+    bySlug: { [slug: string]: Belief },
+    inOrder: List<Belief>,
+  };
+
+  distinctives: {
+    bySlug: { [slug: string]: Distinctive },
+    inOrder: List<Distinctive>,
+  };
+
   events: {
     bySlug: { [slug: string]: Event },
     featured: List<Event>,
     upcoming: List<Event>,
   };
+
+  ministries: {
+    bySlug: { [slug: string]: Ministry },
+  }
 
   pages: {
     bySlug: { [slug: string]: Page },
@@ -48,6 +87,11 @@ export interface Graph {
 
   people: {
     byId: { [id: string]: Person },
+  };
+
+  series: {
+    bySlug: { [slug: string]: Series },
+    recent: List<Series>,
   };
 
   sermons: {

--- a/ui/config.ts
+++ b/ui/config.ts
@@ -1,0 +1,10 @@
+import { ReactElement } from "react";
+import { Graph } from '../model/falcor';
+
+export interface PageConfig<T> {
+  title?(data: Graph, params: T): string;
+  render(data: Graph, params: T): ReactElement<any>;
+  redirects?: 'NO!';
+  urlPattern?: 'NO!';
+  data?(params: T): any; // Graph-esque?
+}

--- a/ui/pages/college.tsx
+++ b/ui/pages/college.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {MinistriesNav} from "../components/ministriesNav";
 import {Page} from "../components/page";
+import {PageConfig} from "../config";
 
-export const CollegePage = {
+export class CollegePage implements PageConfig<{}> {
   render() {
     return (
       <Page title="The Underground College Ministry" nav={<MinistriesNav active="college"/>}>
@@ -15,7 +16,5 @@ export const CollegePage = {
         </p>
       </Page>
     );
-  },
-
-  urlPattern: '/college',
-};
+  }
+}

--- a/ui/pages/eight-distinctives.tsx
+++ b/ui/pages/eight-distinctives.tsx
@@ -3,10 +3,12 @@ import * as gallery from '../components/gallery';
 import {Page} from '../components/page';
 import {AboutNav} from '../components/aboutNav';
 import {slice} from "../slice";
+import {PageConfig} from "../config";
+import {Graph, Distinctive} from "../../model/falcor";
 
-export const DistinctivesPage = {
-  render({data}: any) {
-    const distinctives = slice<any>(data.distinctives.inOrder, 0, 8);
+export class DistinctivesPage implements PageConfig<{}> {
+  render(data: Graph) {
+    const distinctives = slice<Distinctive>(data.distinctives.inOrder, 0, 8);
 
     return (
       <Page title="8 Distinctives" nav={<AboutNav active="eight-distinctives" />}>
@@ -26,9 +28,7 @@ export const DistinctivesPage = {
         </ol>
       </Page>
     );
-  },
-
-  urlPattern: '/eight-distinctives',
+  }
 
   data() {
     return {
@@ -44,5 +44,5 @@ export const DistinctivesPage = {
         },
       },
     };
-  },
-};
+  }
+}

--- a/ui/pages/fellowship.tsx
+++ b/ui/pages/fellowship.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {Page} from "../components/page";
 import {MinistriesNav} from "../components/ministriesNav";
+import {PageConfig} from "../config";
 
-export const FellowshipPage = {
+export class FellowshipPage implements PageConfig<{}> {
   render() {
     return (
       <Page title="Home Fellowship Groups" nav={<MinistriesNav active="fellowship"/>}>
@@ -37,7 +38,5 @@ export const FellowshipPage = {
         </div>
       </Page>
     );
-  },
-
-  urlPattern: '/fellowship',
-};
+  }
+}

--- a/ui/pages/giving.tsx
+++ b/ui/pages/giving.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {Page} from "../components/page";
 import {ContentNav} from "../components/contentNav";
+import {PageConfig} from "../config";
 
-export const GivingPage = {
+export class GivingPage implements PageConfig<{}> {
   render() {
     return (
       <Page title="Give to Compass HB" nav={<ContentNav active="none" />}>
@@ -36,7 +37,5 @@ export const GivingPage = {
         </div>
       </Page>
     );
-  },
-
-  urlPattern: '/giving',
+  }
 }

--- a/ui/pages/index-spec.ts
+++ b/ui/pages/index-spec.ts
@@ -5,8 +5,8 @@ import { IndexPage } from './index';
 describe('IndexPage', function() {
   it("shows the latest sermon's title", function() {
     const result = ReactDOMServer.renderToStaticMarkup(
-      IndexPage.render({
-        data: {
+      new IndexPage().render(
+        {
           sermons: {
             recent: {
               0: {
@@ -32,15 +32,14 @@ describe('IndexPage', function() {
               length: 2,
             },
           },
-        },
-      } as any));
+        } as any));
 
     expect(result.includes('Foo sermon')).toBe(true);
   });
 
   it('Has a section for "Latest sermons"', function() {
-    const result = ReactDOMServer.renderToStaticMarkup(IndexPage.render({
-      data: {
+    const result = ReactDOMServer.renderToStaticMarkup(new IndexPage().render(
+      {
         sermons: {
           recent: {
             0: {
@@ -71,8 +70,8 @@ describe('IndexPage', function() {
             length: 2,
           },
         },
-      },
-    } as any));
+      } as any
+    ));
 
     expect(result.includes('Sermons')).toBe(true);
   });

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -4,9 +4,10 @@ import {Footer} from "../components/footer";
 import {LatestSermon, latestSermonData} from "../components/latestSermon";
 import {slice} from "../slice";
 import {Event, Graph, Sermon} from '../../model/falcor';
+import {PageConfig} from "../config";
 
-export const IndexPage = {
-  title: () => 'CompassHB',
+export class IndexPage implements PageConfig<{}> {
+  title() { return 'CompassHB'; }
 
   data() {
     return {
@@ -38,9 +39,9 @@ export const IndexPage = {
         },
       },
     };
-  },
+  }
 
-  render({data}: {data: Graph}) {
+  render(data: Graph) {
     const [sermon, ...sermons] = slice<Sermon>(data.sermons.recent, 0, 5);
     const events = slice<Event>(data.events.upcoming, 0, 2);
 
@@ -252,7 +253,5 @@ export const IndexPage = {
       </div></div></div>
       <Footer/>
     </div>
-  },
-
-  urlPattern: '/',
-};
+  }
+}

--- a/ui/pages/kids.tsx
+++ b/ui/pages/kids.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {Page} from "../components/page";
 import {MinistriesNav} from "../components/ministriesNav";
+import {PageConfig} from "../config";
 
-export const KidsPage = {
+export class KidsPage implements PageConfig<{}> {
   render() {
     return (
       <Page title="Kids Ministry" nav={<MinistriesNav active="kids"/>}>
@@ -88,7 +89,5 @@ export const KidsPage = {
         <style dangerouslySetInnerHTML={{__html: " .col-md-4 img { border: 6px solid #FFF; } " }} />
       </Page>
     );
-  },
-
-  urlPattern: '/kids',
-};
+  }
+}

--- a/ui/pages/men.tsx
+++ b/ui/pages/men.tsx
@@ -3,19 +3,21 @@ import * as gallery from "../components/gallery";
 import {Page} from "../components/page";
 import {MinistriesNav} from "../components/ministriesNav";
 import {slice} from "../slice";
+import {PageConfig} from "../config";
+import {Graph, Sermon} from "../../model/falcor";
 
-export const MenPage = {
-  render({data}: any) {
-    const sermons = slice<any>(data.ministries.byAlias.men.sermons.recent, 0, 100);
+export class MenPage implements PageConfig<{}> {
+  render(data: Graph) {
+    const sermons = slice<Sermon>(data.ministries.bySlug['men'].sermons.recent, 0, 100);
 
     return (
       <Page title="Men" nav={<MinistriesNav active="men" />}>
         <ol style={gallery.container}>
           {sermons.map((sermon) => (
           <li style={gallery.item}>
-            <a href={`videos/${sermon.alias}`} style={{backgroundImage: `url(${sermon.backgroundImage})`, backgroundSize: 'cover', width: 200, height: 125, display: 'block'}} />
+            <a href={`videos/${sermon.slug}`} style={{backgroundImage: `url(${sermon.coverImage})`, backgroundSize: 'cover', width: 200, height: 125, display: 'block'}} />
             <h4 className="tk-seravek-web">
-              <a href={`videos/${sermon.alias}`}>{sermon.title}</a>
+              <a href={`videos/${sermon.slug}`}>{sermon.title}</a>
             </h4>
             <p>
               <span style={{display: 'block'}}>{sermon.date}</span>
@@ -26,21 +28,19 @@ export const MenPage = {
         </ol>
       </Page>
     );
-  },
-
-  urlPattern: '/men',
+  }
 
   data() {
     return {
       ministries: {
-        byAlias: {
-          men: {
+        bySlug: {
+          ['men']: {
             sermons: {
               recent: {
                 '0..99': {
                   $type: 'range',
-                  alias: true,
-                  backgroundImage: true,
+                  slug: true,
+                  coverImage: true,
                   title: true,
                   date: true,
                   teacher: {
@@ -54,5 +54,5 @@ export const MenPage = {
         },
       },
     };
-  },
-};
+  }
+}

--- a/ui/pages/read.tsx
+++ b/ui/pages/read.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
 import header from "../components/header";
 import footer from "../components/footer";
+import {PageConfig} from "../config";
 
-const {div} = React.DOM;
-
-export const ReadPage = {
+export class ReadPage implements PageConfig<{}> {
   render() {
-    return div({},
-      header(),
-      '/read page',
-      footer()
-    );
-  },
-
-  urlPattern: '/read',
-};
+    return <div>
+      <header />
+      /read page
+      <footer />
+    </div>
+  }
+}

--- a/ui/pages/series.tsx
+++ b/ui/pages/series.tsx
@@ -3,19 +3,21 @@ import * as gallery from "../components/gallery";
 import {Page} from "../components/page";
 import {ContentNav} from "../components/contentNav";
 import {slice} from "../slice";
+import {PageConfig} from "../config";
+import {Graph} from "../../model/falcor";
 
-export const SeriesPage = {
-  render({data}: any) {
+export class SeriesPage implements PageConfig<{}> {
+  render(data: Graph) {
     return (
       <Page title="Sermon Series" nav={<ContentNav active="series" />}>
         <ol style={gallery.container}>
           {slice<any>(data.series.recent, 0, 200).map(series => (
-            <li key={series.alias} style={gallery.item}>
-              <a href={`/series/${series.alias}`}>
+            <li key={series.slug} style={gallery.item}>
+              <a href={`/series/${series.slug}`}>
                 <img src={series.coverImage} width="200" height="125" alt={series.title} />
               </a>
               <h4 className="tk-seravek-web">
-                <a href={`/series/${series.alias}`}>{series.title}</a>
+                <a href={`/series/${series.slug}`}>{series.title}</a>
               </h4>
               <p>{series.description}</p>
             </li>
@@ -23,14 +25,12 @@ export const SeriesPage = {
         </ol>
       </Page>
     );
-  },
-
-  urlPattern: '/series',
+  }
 
   data() {
     return [
       ['series', 'recent', {from: 0, to: 200}, ['alias', 'coverImage', 'description', 'title']],
       ['series', 'recent', 'length'],
     ];
-  },
+  }
 }

--- a/ui/pages/sermons.tsx
+++ b/ui/pages/sermons.tsx
@@ -3,18 +3,11 @@ import * as gallery from "../components/gallery";
 import {Page} from "../components/page";
 import {ContentNav} from "../components/contentNav";
 import {slice} from "../slice";
+import {PageConfig} from "../config";
+import {Graph, Sermon} from "../../model/falcor";
 
-export interface Sermon {
-  slug: string;
-  coverImage: string;
-  date: string;
-  teacher: {name: string};
-  text: string;
-  title: string;
-}
-
-export const SermonsPage = {
-  render({data}: any) {
+export class SermonsPage implements PageConfig<{}> {
+  render(data: Graph) {
     return (
       <Page title="Sermons" nav={<ContentNav active="sermons" />}>
         <ol style={gallery.container}>
@@ -52,9 +45,7 @@ export const SermonsPage = {
         </div>
       </Page>
     );
-  },
-
-  urlPattern: '/sermons',
+  }
 
   data() {
     return {
@@ -73,5 +64,5 @@ export const SermonsPage = {
         },
       },
     };
-  },
-};
+  }
+}

--- a/ui/pages/sermons/single-spec.ts
+++ b/ui/pages/sermons/single-spec.ts
@@ -4,8 +4,8 @@ import { SermonPage } from './single';
 
 describe('SermonPage', function() {
   it('Shows the sermon title', function() {
-    const result = ReactDOMServer.renderToStaticMarkup(SermonPage.render({
-      data: {
+    const result = ReactDOMServer.renderToStaticMarkup(new SermonPage().render(
+      {
         sermons: {
           bySlug: {
             'foo': {
@@ -14,11 +14,11 @@ describe('SermonPage', function() {
             },
           },
         },
-      },
-      params: {
+      } as any,
+      {
         slug: 'foo',
-      },
-    }));
+      }
+    ));
 
     expect(result.includes('Foobar')).toBe(true);
   });

--- a/ui/pages/sermons/single.tsx
+++ b/ui/pages/sermons/single.tsx
@@ -1,20 +1,24 @@
 import * as React from "react";
 import {ContentNav} from "../../components/contentNav";
 import {Page} from "../../components/page";
+import {PageConfig} from "../../config";
+import {Graph} from "../../../model/falcor";
 
-export const SermonPage = {
-  render({data, params}: any) {
-    const sermon = data.sermons.bySlug[params.slug];
+export interface Params {
+  slug: string;
+}
+
+export class SermonPage implements PageConfig<Params> {
+  render(data: Graph, {slug}: Params) {
+    const sermon = data.sermons.bySlug[slug];
 
     // TODO(ewinslow): Use an HTML sanitizer or something}
     return <Page title={sermon.title} nav={<ContentNav active="sermons" />}>
       <div dangerouslySetInnerHTML={{__html: sermon.content}}></div>
     </Page>;
-  },
+  }
 
-  urlPattern: '/sermons/:slug',
-
-  data({slug}: {slug: string}) {
+  data({slug}: Params) {
     return {
       sermons: {
         bySlug: {
@@ -25,5 +29,5 @@ export const SermonPage = {
         },
       },
     };
-  },
-};
+  }
+}

--- a/ui/pages/single.tsx
+++ b/ui/pages/single.tsx
@@ -1,9 +1,15 @@
 import * as React from "react";
 import {ContentNav} from "../components/contentNav";
 import {Page} from "../components/page";
+import {PageConfig} from "../config";
+import {Graph} from "../../model/falcor";
 
-export const PagesPage = {
-  render({data, params}: any) {
+export interface Params {
+  slug: string;
+}
+
+export class PagesPage implements PageConfig<Params> {
+  render(data: Graph, params: Params) {
     // TODO(): redirect 404 if results are undefined
     const page = data.pages.bySlug[params.slug];
 
@@ -11,11 +17,9 @@ export const PagesPage = {
     return <Page title={page.title}>
       <div dangerouslySetInnerHTML={{__html: page.content}}></div>
     </Page>;
-  },
+  }
 
-  urlPattern: '/:slug',
-
-  data({slug}: {slug: string}) {
+  data({slug}: Params) {
     return {
       pages: {
         bySlug: {
@@ -26,5 +30,5 @@ export const PagesPage = {
         },
       },
     };
-  },
-};
+  }
+}

--- a/ui/pages/songs.tsx
+++ b/ui/pages/songs.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
 import header from "../components/header";
 import footer from "../components/footer";
+import {PageConfig} from "../config";
 
-export const SongsPage = {
+export class SongsPage implements PageConfig<{}> {
   render() {
-    return React.DOM.div({},
-      header(),
-      '/songs page',
-      footer()
-    );
-  },
-
-  urlPattern: '/songs',
-};
+    return <div>
+      <header />
+      /songs page
+      <footer />
+    </div>;
+  }
+}

--- a/ui/pages/sundayschool.tsx
+++ b/ui/pages/sundayschool.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {Page} from "../components/page";
 import {MinistriesNav} from "../components/ministriesNav";
+import {PageConfig} from "../config";
 
-export const SundaySchoolPage = {
+export class SundaySchoolPage implements PageConfig<{}> {
   render() {
     return (
       <Page title="Sunday School" nav={<MinistriesNav active="sundayschool" />}>
@@ -73,7 +74,5 @@ export const SundaySchoolPage = {
         </div>
       </Page>
     );
-  },
-
-  urlPattern: '/sundayschool',
-};
+  }
+}

--- a/ui/pages/videos.tsx
+++ b/ui/pages/videos.tsx
@@ -1,17 +1,14 @@
 import * as React from "react";
 import header from "../components/header";
 import footer from "../components/footer";
+import {PageConfig} from "../config";
 
-const {div, ul, li, link, h1, html, head, img, body, a, meta, script, span} = React.DOM;
-
-export const VideosPage = {
+export class VideosPage implements PageConfig<{}> {
   render() {
-    return div({},
-      header(),
-      '/videos page',
-      footer()
-    );
-  },
-
-  urlPattern: '/videos',
-};
+    return <div>
+      <header />
+      /videos page,
+      <footer />
+    </div>;
+  }
+}

--- a/ui/pages/what-we-believe.tsx
+++ b/ui/pages/what-we-believe.tsx
@@ -3,6 +3,8 @@ import * as gallery from '../components/gallery';
 import {AboutNav} from '../components/aboutNav';
 import {Page} from '../components/page';
 import {slice} from '../slice';
+import {PageConfig} from "../config";
+import {Graph, Belief} from "../../model/falcor";
 
 const styles = {
   heading: {
@@ -10,9 +12,9 @@ const styles = {
   },
 };
 
-export const WhatWeBelievePage = {
-  render({data}: any) {
-    const beliefs = slice(data.beliefs.inOrder, 0, 8);
+export class WhatWeBelievePage implements PageConfig<{}> {
+  render(data: Graph) {
+    const beliefs = slice<Belief>(data.beliefs.inOrder, 0, 8);
     return (
       <Page title="What We Believe" nav={<AboutNav active="what-we-believe" />}>
         <ul style={gallery.container}>
@@ -25,13 +27,7 @@ export const WhatWeBelievePage = {
         </ul>
       </Page>
     );
-  },
-
-  urlPattern: '/what-we-believe',
-
-  redirects: {
-    '/what-we-believe': 301,
-  } as {[url: string]: number},
+  }
 
   data() {
     return {
@@ -46,5 +42,5 @@ export const WhatWeBelievePage = {
         },
       },
     };
-  },
-};
+  }
+}

--- a/ui/pages/who-we-are.tsx
+++ b/ui/pages/who-we-are.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {Page} from '../components/page';
 import {AboutNav} from '../components/aboutNav';
+import {PageConfig} from "../config";
 
-export const WhoWeArePage = {
+export class WhoWeArePage implements PageConfig<{}> {
   render() {
     return (
       <Page title="Welcome to Compass Bible Church Huntington Beach" nav={<AboutNav active="who-we-are" />}>
@@ -113,7 +114,5 @@ export const WhoWeArePage = {
         </div>
       </Page>
     );
-  },
-
-  urlPattern: '/who-we-are',
+  }
 };

--- a/ui/pages/women.tsx
+++ b/ui/pages/women.tsx
@@ -1,15 +1,12 @@
 import * as React from "react";
 import {MinistriesNav} from "../components/ministriesNav";
 import {Page} from "../components/page";
+import {PageConfig} from "../config";
 
-const {div} = React.DOM;
-
-export const WomenPage = {
+export class WomenPage implements PageConfig<{}> {
   render() {
     return <Page title="Women" nav={<MinistriesNav active="women" />}>
       Sermons by Christa...
     </Page>;
-  },
-
-  urlPattern: '/women',
-};
+  }
+}

--- a/ui/pages/youth.tsx
+++ b/ui/pages/youth.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import {Page} from "../components/page";
 import {MinistriesNav} from "../components/ministriesNav";
+import {PageConfig} from "../config";
 
-export const YouthPage = {
+export class YouthPage implements PageConfig<{}> {
   render() {
     return (
       <Page title="The United Student Ministry" nav={<MinistriesNav active="youth" />}>
@@ -43,7 +44,5 @@ export const YouthPage = {
         <style dangerouslySetInnerHTML={{__html: " .col-md-4 img { border: 6px solid #FFF; } .col-md-4 { color: #fff; } " }} />
       </Page>
     );
-  },
-
-  urlPattern: '/youth',
-};
+  }
+}


### PR DESCRIPTION
New URLs can go here and it will serve as the source of truth for our URL structure.

Also adds more type safety to our pages. This helped catch several bugs in our React elements.

Fixes #43