### PR TITLE
Pull content for Scripture of the Day page from WordPress

### DIFF
--- a/model/falcor.ts
+++ b/model/falcor.ts
@@ -30,6 +30,17 @@ export interface Page {
   title: string;
 }
 
+export interface Passage {
+  title: string;
+  slug: string;
+  content: string;
+  overview: string;
+  activity: {
+    today: number,
+    now: number,
+  };
+}
+
 export interface Person {
   name: string;
   slug: string;
@@ -83,6 +94,11 @@ export interface Graph {
 
   pages: {
     bySlug: { [slug: string]: Page },
+  };
+
+  passages: {
+    recent: List<Passage>,
+    bySlug: { [slug: string]: Passage },
   };
 
   people: {

--- a/model/router.ts
+++ b/model/router.ts
@@ -1,12 +1,21 @@
 import * as Router from "falcor-router";
 import * as moment from "moment";
 import { PathValue, Range, ref } from "falcor-json-graph";
-import { Site } from './wordpress';
+import { Site, Sermon } from './wordpress';
 import { assert, pathValue } from './debug';
 
 const LONG_DATE = 'dddd, MMMM D, YYYY';
 
 const wp = new Site('https://api.compasshb.com/wp-json/wp/v2');
+const reading = new Site('https://api.compasshb.com/reading/wp-json/wp/v2');
+
+function getPassagePaths(passage: Sermon) {
+  return [
+    pathValue(['passages', 'bySlug', passage.slug, 'overview'], () => passage.content.rendered),
+    pathValue(['passages', 'bySlug', passage.slug, 'slug'], () => passage.slug),
+    pathValue(['passages', 'bySlug', passage.slug, 'title'], () => passage.title.rendered),
+  ];
+}
 
 export const router = new Router([
   {
@@ -217,6 +226,76 @@ export const router = new Router([
       }
 
       return promise;
+    },
+  },
+  {
+    route: 'passages.recent[{ranges}]',
+    async get([,,ranges]: [any, any, Array<{from:number,to:number}>]): Promise<Array<PathValue>> {
+      const results: Array<PathValue> = [];
+
+      // Not sure why, but TypeScript keeps using yield here when we try to make this an async function
+      // For now, we'll have to use this promise-chaining approach which is still nicer than Observables IMO
+      let promise = Promise.resolve(results);
+      for (const {from = 0, to} of ranges) {
+        promise = promise.then(() => reading.getSermons({ offset: from, limit: to - from + 1 })).then((passages) => {
+          passages.forEach((passage, i) => {
+            results.push({
+              path: ['passages', 'recent', from + i],
+              value: ref(['passages', 'bySlug', passage.slug]),
+            });
+
+            results.push(...getPassagePaths(passage));
+          });
+
+          return results;
+        });
+      }
+
+      return promise;
+    },
+  },
+  {
+    route: 'passages.recent.length',
+    async get(): Promise<Array<PathValue>> {
+      return [{
+        path: ['passages', 'recent', 'length'],
+        value: await reading.getSermonsCount(),
+      }];
+    },
+  },
+  {
+    route: 'passages.bySlug[{keys}]["slug","title","content","overview"]',
+    async get([,,slugs,props]: [any, any, Array<string>, Array<string>]): Promise<Array<PathValue>> {
+      const results: Array<PathValue> = [];
+
+      let promise = Promise.resolve(results);
+      for (const slug of slugs) {
+        promise = promise.then(() => reading.getSermonBySlug(slug)).then((passage) => {
+          results.push(...getPassagePaths(passage));
+
+          if (props.indexOf('content') >= 0) {
+            results.push(pathValue(['passages', 'bySlug', passage.slug, 'content'], () => 'TODO: Fetch from ESV API'));
+          }
+
+          return results;
+        });
+      }
+
+      return promise;
+    },
+  },
+  {
+    route: 'passages.bySlug[{keys}].activity["today","now"]',
+    async get([,,slugs]: [any,any,Array<string>]): Promise<Array<PathValue>> {
+      const results: Array<PathValue> = [];
+
+      for (const slug of slugs) {
+        // TODO(ewinslow): Get real numbers from Google Analytics?
+        results.push(pathValue(['passages', 'bySlug', slug, 'activity', 'today'], () => 86));
+        results.push(pathValue(['passages', 'bySlug', slug, 'activity', 'now'], () => 2));
+      }
+
+      return results;
     },
   },
 ]);

--- a/ui/pages/read.tsx
+++ b/ui/pages/read.tsx
@@ -1,14 +1,59 @@
 import * as React from "react";
-import {Header} from "../components/header";
-import {Footer} from "../components/footer";
+import {Page} from "../components/page";
 import {PageConfig} from "../config";
+import {Graph, Passage} from "../../model/falcor";
+import {slice} from "../slice";
 
 export class ReadPage implements PageConfig {
-  render() {
-    return <div>
-      <Header />
-      /read page
-      <Footer />
-    </div>
+  title(data: Graph) {
+    return "Scripture of the Day";
+  }
+
+  render(data: Graph) {
+    const passage = data.passages.recent[0];
+    const passages = slice<Passage>(data.passages.recent, 0, 7);
+
+    return <Page title={passage.title}>
+      <div dangerouslySetInnerHTML={{__html: passage.content}}></div>
+      <h3>Bible Overview</h3>
+      <div dangerouslySetInnerHTML={{__html: passage.overview}}></div>
+      <br/>
+      <p> {passage.activity.today} people have read today. {passage.activity.now} active users. </p>
+      {/* TODO(ewinslow): Pull this from the ESV API */}
+      <audio src="https://audio.esvbible.org/hw/43012001-43012050.mp3" controls />
+      <h5 className="tk-seravek-web">This Week</h5>
+      <ul>
+        {passages.map(({slug, title}) => (
+        <li><a href={`/read/${slug}`}>{title}</a></li>
+        ))}
+      </ul>
+      <br/>
+      TODO: Disqus comments go here...
+    </Page>
+  }
+
+  data() {
+    return {
+      passages: {
+        recent: {
+          "0": {
+            title: true,
+            content: true,
+            overview: true,
+            slug: true,
+            activity: {
+              today: true,
+              now: true,
+            },
+          },
+          "0..7": {
+            $type: 'range',
+            title: true,
+            slug: true,
+          },
+          length: true,
+        },
+      },
+    };
   }
 }


### PR DESCRIPTION
Still need to:

 * Pull activity info from Google Analytics
 * Pull actual Bible text from ESV API
 * Parse out the audio from ESV API
 * Pull in Disqus comments
 * Implement standalone pages for viewing older passages

Refs #69